### PR TITLE
Fix issue #133

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
     copy: {
       data: {
         expand: true,
-        src: path.join('data',"*"),
+        src: path.join('data',"**"),
         dest: WEB_ROOT
       },
       js: {


### PR DESCRIPTION
Fixes #133. Not all files in `data` directory are being copied to `public/data`, where the files are being served by grunt-contrib-connect. 